### PR TITLE
SIGM 3.0.1-M2 funcional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 /.project
+sigem/SIGEM_DIST

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 /.project
 sigem/SIGEM_DIST
+RELEASE

--- a/archivo/archidoc_main/pom.xml
+++ b/archivo/archidoc_main/pom.xml
@@ -675,14 +675,8 @@
 	</build>
 	<distributionManagement>
 		<repository>
-			<id>releases</id>
-			<name>Repositorio de releases</name>
-			<url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
 		</repository>
-		<snapshotRepository>
-			<id>snapshots</id>
-			<name>Repositorio de snapshots</name>
-			<url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
 	</distributionManagement>
 </project>

--- a/archivo/pom.xml
+++ b/archivo/pom.xml
@@ -65,7 +65,8 @@
 				</property>
 			</activation>
 			<modules>
-				<module>archidoc_ear</module>
+                                <!-- No hay directorio archidoc_ear!!! -->
+				<!-- module>archidoc_ear</module -->
 				<!-- module>archidocWS</module-->
 			</modules>
 		</profile>

--- a/archivo/pom.xml
+++ b/archivo/pom.xml
@@ -15,15 +15,9 @@
 
 	<distributionManagement>
 		<repository>
-			<id>releases</id>
-			<name>Repositorio de releases</name>
-			<url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
 		</repository>
-		<snapshotRepository>
-			<id>snapshots</id>
-			<name>Repositorio de snapshots</name>
-			<url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
 	</distributionManagement>
 	<profiles>
 		<profile>

--- a/framework-audit/pom.xml
+++ b/framework-audit/pom.xml
@@ -18,17 +18,6 @@
 	<name>fwktd-audit</name>
 	<description>Modulo de auditoria</description>
 
-  <repositories>
-    <repository>
-      <id>googlecode</id>
-      <url>http://lhg.googlecode.com/svn/!svn/bc/807/repository/</url>
-    </repository>
-    <repository>
-      <id>uji</id>
-      <url>http://devel.uji.es/nexus/content/groups/public/</url>
-    </repository>
-  </repositories>
-
   <properties>
 
 		<!-- Framework dependencies -->

--- a/framework-csv/fwktd-csv-webapp/pom.xml
+++ b/framework-csv/fwktd-csv-webapp/pom.xml
@@ -16,13 +16,6 @@
 		<unpack.config.directory>${project.build.directory}/generated-resources</unpack.config.directory>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>uji</id>
-      <url>http://devel.uji.es/nexus/content/groups/public/</url>
-    </repository>
-  </repositories>
-
 	<dependencies>
 
 		<!-- fwktd-csv dependencies -->

--- a/framework-filesystem-applet/pom.xml
+++ b/framework-filesystem-applet/pom.xml
@@ -15,6 +15,12 @@
 		<skipDeploy>false</skipDeploy>
 	</properties>	
 	
+	<distributionManagement>
+		<repository>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
+		</repository>
+	</distributionManagement>
 	
 	<dependencies>
 		<dependency>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -64,6 +64,13 @@
     <itext.version>2.1.7</itext.version>
   </properties>
 
+  <distributionManagement>
+    <repository>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
+    </repository>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,13 @@
     <maven>2.0.9</maven>
   </prerequisites>
 
+  <distributionManagement>
+    <repository>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
+    </repository>
+  </distributionManagement>
+
   <modules>
     <module>framework</module>
     <module>framework-audit</module>

--- a/registro/ISicres-Document-Connector/pom.xml
+++ b/registro/ISicres-Document-Connector/pom.xml
@@ -21,7 +21,7 @@
 		</dependency>
 		
 		<dependency>
-			<groupId>xstream</groupId>
+			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.2.2</version>
 		</dependency>	

--- a/registro/ISicres-WS-legacy/pom.xml
+++ b/registro/ISicres-WS-legacy/pom.xml
@@ -173,8 +173,6 @@
 					<source>1.5</source>
 					<target>1.5</target>
 					<encoding>iso-8859-1</encoding>
-					<fork>true</fork>
-					<executable>${JAVA_1_5_HOME}/bin/javac</executable>
 				</configuration>
 			</plugin>
 

--- a/registro/InvesicresAdmin/pom.xml
+++ b/registro/InvesicresAdmin/pom.xml
@@ -144,14 +144,8 @@
 	</profiles>
   <distributionManagement>
     <repository>
-      <id>releases</id>
-      <name>Repositorio de releases</name>
-      <url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
     </repository>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <name>Repositorio de snapshots</name>
-      <url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
   </distributionManagement>
 </project>

--- a/registro/pom.xml
+++ b/registro/pom.xml
@@ -226,16 +226,10 @@
 
   <distributionManagement>
     <repository>
-      <id>releases</id>
-      <name>Repositorio de releases</name>
-      <url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
     </repository>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <name>Repositorio de snapshots</name>
-      <url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-      </snapshotRepository>
-    </distributionManagement>
+  </distributionManagement>
 
   <modules>
     <module>ISicres-Terceros</module>

--- a/sigem/SIGEM_Archivo_Modules/SIGEM_Archivo_War/pom.xml
+++ b/sigem/SIGEM_Archivo_Modules/SIGEM_Archivo_War/pom.xml
@@ -143,7 +143,7 @@
 			<plugin>
 				<groupId>es.ieci.maven.plugins</groupId>
 				<artifactId>maven-generate-resources-archivo-plugin</artifactId>
-				<version>1.0</version>
+				<version>1.1</version>
 				<executions>
 					<execution>
 						<id>modified-resources</id>

--- a/sigem/SIGEM_Config/pom.xml
+++ b/sigem/SIGEM_Config/pom.xml
@@ -319,7 +319,7 @@
 		<!-- SIGEM_Consolidacion -->
 		<dependency>
 			<groupId>es.ieci.tecdoc.sigem</groupId>
-			<artifactId>SIGEM_Consolidacion</artifactId>
+			<artifactId>sigem_consolidacion</artifactId>
 			<version>${pom.version}</version>
 			<type>zip</type>
 			<classifier>configurableSigem</classifier>

--- a/sigem/SIGEM_ConsultaExpedienteBackOfficeWeb/pom.xml
+++ b/sigem/SIGEM_ConsultaExpedienteBackOfficeWeb/pom.xml
@@ -14,7 +14,7 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>activation</groupId>
+			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
 			<version>1.0.2</version>
 		</dependency>
@@ -234,7 +234,7 @@
 
 		<dependency>
 			<groupId>xerces</groupId>
-			<artifactId>xerces</artifactId>
+			<artifactId>xercesImpl</artifactId>
 			<version>2.4.0</version>
 		</dependency>
 
@@ -268,7 +268,7 @@
   			<version>1.0</version>
   		</dependency>
   		<dependency>
-  			<groupId>jstl</groupId>
+  			<groupId>javax.servlet</groupId>
   			<artifactId>jstl</artifactId>
   			<version>1.0.2</version>
 		</dependency>

--- a/sigem/SIGEM_ConsultaWeb/pom.xml
+++ b/sigem/SIGEM_ConsultaWeb/pom.xml
@@ -14,7 +14,7 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>activation</groupId>
+			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
 			<version>1.0.2</version>
 		</dependency>
@@ -272,7 +272,7 @@
 
 		<dependency>
 			<groupId>xerces</groupId>
-			<artifactId>xerces</artifactId>
+			<artifactId>xercesImpl</artifactId>
 			<version>2.4.0</version>
 		</dependency>
 
@@ -307,7 +307,7 @@
   			<version>1.0</version>
   		</dependency>
   		<dependency>
-  			<groupId>jstl</groupId>
+  			<groupId>javax.servlet</groupId>
   			<artifactId>jstl</artifactId>
   			<version>1.0.2</version>
 		</dependency>

--- a/sigem/SIGEM_Core/pom.xml
+++ b/sigem/SIGEM_Core/pom.xml
@@ -55,7 +55,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>axis</groupId>
+			<groupId>org.apache.axis</groupId>
 			<artifactId>axis-ant</artifactId>
 			<version>1.4</version>
 			<scope>provided</scope>
@@ -118,7 +118,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xstream</groupId>
+			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.2.2</version>
 		</dependency>

--- a/sigem/SIGEM_EstructuraWeb/pom.xml
+++ b/sigem/SIGEM_EstructuraWeb/pom.xml
@@ -143,7 +143,7 @@
 		</dependency>
 		
 		<dependency>
-			<groupId>jspapi</groupId>
+			<groupId>javax.servlet</groupId>
 			<artifactId>jsp-api</artifactId>
 			<version>2.0</version>
 			<scope>provided</scope>

--- a/sigem/SIGEM_GestionCSV_Modules/SIGEM_GestionCSVWeb/pom.xml
+++ b/sigem/SIGEM_GestionCSV_Modules/SIGEM_GestionCSVWeb/pom.xml
@@ -150,6 +150,7 @@
 			<plugin>
 				<groupId>org.appfuse.plugins</groupId>
 				<artifactId>maven-warpath-plugin</artifactId>
+				<version>2.2.1</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/sigem/SIGEM_PagoElectronico_Modules/pom.xml
+++ b/sigem/SIGEM_PagoElectronico_Modules/pom.xml
@@ -35,7 +35,7 @@
 			<modules>
 				<module>SIGEM_PagoElectronico-configurable-resources</module>
 				<module>SIGEM_PagoElectronico</module>
-				<module>SIGEM_PagoElectronicoWSClient</module>
+				<module>sigem_pagoElectronicoWsClient</module>
 			</modules>
 		</profile>
 		<profile>

--- a/sigem/SIGEM_PagoElectronico_Modules/pom.xml
+++ b/sigem/SIGEM_PagoElectronico_Modules/pom.xml
@@ -35,7 +35,7 @@
 			<modules>
 				<module>SIGEM_PagoElectronico-configurable-resources</module>
 				<module>SIGEM_PagoElectronico</module>
-				<module>sigem_pagoElectronicoWsClient</module>
+				<module>SIGEM_PagoElectronicoWSClient</module>
 			</modules>
 		</profile>
 		<profile>

--- a/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencial/pom.xml
+++ b/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencial/pom.xml
@@ -165,7 +165,7 @@
 			<version>3.0</version>
 		</dependency>
 		<dependency>
-			<groupId>xstream</groupId>
+			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.2.2</version>
 		</dependency>

--- a/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencialAdminWeb/pom.xml
+++ b/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencialAdminWeb/pom.xml
@@ -347,9 +347,9 @@
 
 		<!-- plugin de overlay correcto con dependencias -->
 		 	<plugin>
-				<groupId>org.appfuse</groupId>
-				<artifactId>maven-warpath-plugin</artifactId>
-				 <version>2.0.2</version>
+				 <groupId>org.appfuse.plugins</groupId>
+				 <artifactId>maven-warpath-plugin</artifactId>
+				 <version>2.2.1</version>
 				 <extensions>true</extensions>
 			      <executions>
 			        <execution>

--- a/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencialAdminWeb/pom.xml
+++ b/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_RegistroPresencialAdminWeb/pom.xml
@@ -220,7 +220,7 @@
 			<resource>
 				<filtering>true</filtering>
 				<directory>${unpack.config.directory}/SIGEM_RegistroPresencial/Isicres</directory>
-				<targetPath>/SIGEM_RegistroPresencial</targetPath>
+				<!--targetPath>/SIGEM_RegistroPresencial</targetPath-->
 				<excludes>
 					<exclude>**/log4j.xml</exclude>
 				</excludes>

--- a/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_fwktd-sir-ws/pom.xml
+++ b/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_fwktd-sir-ws/pom.xml
@@ -15,15 +15,9 @@
 
   <distributionManagement>
     <repository>
-      <id>releases</id>
-      <name>Repositorio de releases</name>
-      <url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
     </repository>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <name>Repositorio de snapshots</name>
-      <url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
   </distributionManagement>
 
 	<properties>

--- a/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_fwktd-sir-ws/pom.xml
+++ b/sigem/SIGEM_RegistroPresencial_Modules/SIGEM_fwktd-sir-ws/pom.xml
@@ -117,7 +117,7 @@
 		 	<plugin>
 				<groupId>org.appfuse.plugins</groupId>
 				<artifactId>maven-warpath-plugin</artifactId>
-				<version>2.1.0</version>
+				<version>2.2.1</version>
 				<extensions>true</extensions>
 			    <executions>
 			        <execution>

--- a/sigem/SIGEM_Scheduler_Modules/SIGEM_SchedulerWeb/pom.xml
+++ b/sigem/SIGEM_Scheduler_Modules/SIGEM_SchedulerWeb/pom.xml
@@ -30,7 +30,7 @@
 
 		<dependency>
 			<groupId>es.ieci.tecdoc.sigem</groupId>
-			<artifactId>SIGEM_Consolidacion</artifactId>
+			<artifactId>sigem_consolidacion</artifactId>
 			<version>${pom.version}</version>
 		</dependency>
 

--- a/sigem/SIGEM_SignoWS_Modules/SIGEM_SignoWS/pom.xml
+++ b/sigem/SIGEM_SignoWS_Modules/SIGEM_SignoWS/pom.xml
@@ -195,12 +195,12 @@
 		</dependency>
 		<dependency>
 			<groupId>es.ieci.tecdoc.sigem</groupId>
-			<artifactId>SIGEM_PagoElectronicoWSClient</artifactId>
+			<artifactId>sigem_pagoElectronicoWsClient</artifactId>
 			<version>${pom.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>es.ieci.tecdoc.sigem</groupId>
-			<artifactId>SIGEM_RegistroTelematico</artifactId>
+			<artifactId>sigem_registroTelematico</artifactId>
 			<version>${pom.version}</version>
 			<exclusions>
 				<exclusion>

--- a/sigem/pom.xml
+++ b/sigem/pom.xml
@@ -377,6 +377,53 @@
 				</plugins>
 			</build>
 		</profile>
+		<!-- 
+		   Este profile debe ejecutarse con el anterior -Dears -Pgenerate-distri -Pbuild-release 
+		-->
+		<profile>
+			<id>build-release</id>
+			<activation>
+				<property>
+					<name>brelease</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>copy-wars</id>
+								<phase>package</phase>
+								<configuration>
+									<tasks>
+										<property name="dist.dir" value="${basedir}/../RELEASE/SIGM-${project.version}"/>
+										<property name="vers" value="${project.version}"/>
+
+										<delete dir="${dist.dir}"/>
+
+										<mkdir dir="${dist.dir}/Binarios"/>
+										<mkdir dir="${dist.dir}/BD"/>
+										<mkdir dir="${dist.dir}/config"/>
+
+										<copy overwrite="true" todir="${dist.dir}/Binarios" verbose="true">
+											<fileset dir="${basedir}/SIGEM_DIST/" includes="*.war"/>
+										</copy>
+										<copy overwrite="true" todir="${dist.dir}/config" verbose="true" file="${basedir}/SIGEM_DIST/sigem_config-${vers}.zip" />
+										<unzip dest="${dist.dir}/BD/" src="${basedir}/SIGEM_DIST/sigem_bd_dist-${vers}-bd.zip" />
+										<zip destfile="${dist.dir}.zip" basedir="${dist.dir}" />
+									</tasks>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
 		<profile>
 			<id>generate-registroPresencial-distri</id>

--- a/sigem/pom.xml
+++ b/sigem/pom.xml
@@ -11,6 +11,13 @@
 		<maven>2.0.9</maven>
 	</prerequisites>
 
+	<distributionManagement>
+		<repository>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
+		</repository>
+	</distributionManagement>
+
 	<profiles>
 
 		<profile>

--- a/sigem/sigem_main/pom.xml
+++ b/sigem/sigem_main/pom.xml
@@ -35,15 +35,9 @@
 
   <distributionManagement>
     <repository>
-      <id>releases</id>
-      <name>Repositorio de releases</name>
-      <url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+      <id>local-deploy</id>
+      <url>${DeployDir}</url>
     </repository>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <name>Repositorio de snapshots</name>
-      <url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
   </distributionManagement>
 
 	<properties>
@@ -195,11 +189,11 @@
 					</configuration>
 				</plugin>
 
-				<plugin>
+				<!--plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.4</version>
-				</plugin>
+				</plugin-->
 
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>

--- a/tramitador/ispac-docs/pom.xml
+++ b/tramitador/ispac-docs/pom.xml
@@ -169,27 +169,24 @@
 							</execution>
 						</executions>
 					</plugin>
-					<!--plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-assembly-plugin</artifactId>
-						<version>2.2-beta-3</version>
-						<executions>
-							<execution>
-								<id>assembly-resources</id>
-								<phase>package</phase>
-								<goals>
-									<goal>single</goal>
-								</goals>
-								<configuration>
-									<descriptors>
-										<descriptor>
-											src/main/assembly/dep.xml
-										</descriptor>
-									</descriptors>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin-->
+		                        <plugin>
+                                		<artifactId>maven-assembly-plugin</artifactId>
+                		                <version>2.1</version>
+		                                <configuration>
+                                		        <descriptors>
+                		                                <descriptor>src/main/assembly/dep.xml</descriptor>
+		                                        </descriptors>
+                                		</configuration>
+                		                <executions>
+		                                        <execution>
+                                                		<id>assembly-common-resources</id>
+                                		                <goals>
+                		                                        <goal>single</goal>
+		                                                </goals>
+                                                		<phase>install</phase>
+                                		        </execution>
+                		                </executions>
+		                        </plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/tramitador/ispac-main/pom.xml
+++ b/tramitador/ispac-main/pom.xml
@@ -25,15 +25,9 @@
 
 	<distributionManagement>
 		<repository>
-			<id>releases</id>
-			<name>Repositorio de releases</name>
-			<url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
 		</repository>
-		<snapshotRepository>
-			<id>snapshots</id>
-			<name>Repositorio de snapshots</name>
-			<url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
 	</distributionManagement>
 
 	<properties>

--- a/tramitador/pom.xml
+++ b/tramitador/pom.xml
@@ -145,7 +145,7 @@
 								<phase>package</phase>
 								<configuration>
 									<tasks>
-										<property name="dist.dir" value="/invesFlow/${pom.version}"/>
+										<property name="dist.dir" value="${project.build.directory}/invesFlow/${pom.version}"/>
 
 										<delete dir="${dist.dir}"/>
 										<mkdir dir="${dist.dir}" />

--- a/tramitador/pom.xml
+++ b/tramitador/pom.xml
@@ -16,18 +16,11 @@
 		<maven>2.0.9</maven>
 	</prerequisites>
 
-
 	<distributionManagement>
 		<repository>
-			<id>releases</id>
-			<name>Repositorio tecdoc de releases</name>
-			<url>http://devel.uji.es/nexus/content/repositories/releases/</url>
+			<id>local-deploy</id>
+			<url>${DeployDir}</url>
 		</repository>
-		<snapshotRepository>
-			<id>snapshots</id>
-			<name>Repositorio tecdoc de snapshots</name>
-			<url>http://devel.uji.es/nexus/content/repositories/snapshots/</url>
-		</snapshotRepository>
 	</distributionManagement>
 
 	<profiles>


### PR DESCRIPTION
Cambios para poder compilar el proyecto y generar todos los artefactos. La versión que de artefactos que genera es la **3.0.1-M2**.  Para ello,

1. Se han corregido diversos errores en los `pom.xml`
2. Se ha creado un `branch  mvn-repo` con las dependencias de terceros que ya no descargan de maven central
3. Se añade soporte para la ejecución de `mvn deploy` y poder generar todos los artefactos en un directorio concreto que se le pasa como argumento.
4. Se han tratado de minimizar el número de *`WARNING`* que genera maven.

Todo el proyecto puede compilarse ahora en Linux (al menos) usando **MAVEN 2.2.1**  y  **Java 1.6.0_45**
